### PR TITLE
Remove duplicated navigation properties

### DIFF
--- a/Chapter_04/Exercises/Model/ApplicationDbContext.cs
+++ b/Chapter_04/Exercises/Model/ApplicationDbContext.cs
@@ -46,22 +46,6 @@ namespace MyBGList.Models
                 .IsRequired()
                 .OnDelete(DeleteBehavior.Cascade);
 
-            modelBuilder.Entity<BoardGames_Mechanics>()
-                .HasKey(i => new { i.BoardGameId, i.MechanicId });
-
-            modelBuilder.Entity<BoardGames_Mechanics>()
-                .HasOne(x => x.BoardGame)
-                .WithMany(y => y.BoardGames_Mechanics)
-                .HasForeignKey(f => f.BoardGameId)
-                .IsRequired()
-                .OnDelete(DeleteBehavior.Cascade);
-            modelBuilder.Entity<BoardGames_Mechanics>()
-                .HasOne(o => o.Mechanic)
-                .WithMany(m => m.BoardGames_Mechanics)
-                .HasForeignKey(f => f.MechanicId)
-                .IsRequired()
-                .OnDelete(DeleteBehavior.Cascade);
-
             modelBuilder.Entity<BoardGame>()
                 .HasOne(x => x.Publisher)
                 .WithMany(y => y.BoardGames)


### PR DESCRIPTION
Hello

I was doing the exercises in your book, and I found in the answers that this part of the navigation properties for the `BoardGames_Mechanics` were duplicated.

I do not know if an issue must be created first, or if there are any guidelines, when it comes to contribution