### PR TITLE
FIX In memory cache for recordCount - Exercises

### DIFF
--- a/Chapter_08/Exercises/BoardGamesController.cs
+++ b/Chapter_08/Exercises/BoardGamesController.cs
@@ -55,7 +55,7 @@ namespace MyBGList.Controllers
                         .Skip(input.PageIndex * input.PageSize)
                         .Take(input.PageSize);
                 dataTuple.result = await query.ToArrayAsync();
-                _memoryCache.Set(cacheKey, dataTuple.result, new TimeSpan(0, 0, 30));
+                _memoryCache.Set(cacheKey, dataTuple, new TimeSpan(0, 0, 30));
             }
 
             return new RestDTO<BoardGame[]>()


### PR DESCRIPTION
Hallo
In exercise **8.5.4 In-memory caching** I found the following Bug, where the in memory caching is not working.


_Explanation:_
The idea is to cache the `recordCound` and the `results`, but  when the key is set in the dictionary, here
`_memoryCache.Set(cacheKey, dataTuple.result, new TimeSpan(0, 0, 30));`

just the array of boardGames[] is being passed (in the element `dataTuple.result`), rather than the tuple `dataTuple`, and because of that, here 👇 in the IF statement

```csharp

// Exercise 8.5.4
(int recordCount, BoardGame[]? result) dataTuple = (0, null);
var cacheKey = $"{input.GetType()}-{JsonSerializer.Serialize(input)}";

// Here the IF statement fails or is false, because
// the out parameter is not a tuple, but an array of boardgames (because it was being set with dataTuple.result)
// and because of that it is always false and as a result the results are not being obtained
// through the dictionary
if (!_memoryCache.TryGetValue(cacheKey, out dataTuple))
```

Another problem is the following, because we are not storing the entire tuple the `recordCount` always will be zero/null, because this part always will be zero 👇
```csharp
return new RestDTO<BoardGame[]>()
            {
                Data = dataTuple.result, // Exercise 8.5.4
                ....
}
```


Here is a Video proving my theory.
First I run the original solution, with two break points, just as you explain in your Book, then I go to the browser and refresh the site several times to prove that the cache is not working, then I just change the value that we SET in the dictionary/cache and restart Visual Studio and run everything again, where we can see that the cache works.

https://github.com/Darkseal/ASP.NET-Core-Web-API/assets/70602890/e2bb4aa4-811e-4cb6-b42a-10e670642ce6

